### PR TITLE
throw 404 when unable to convert in BasePropertyValueProvider

### DIFF
--- a/PseudoCQRS.Mvc/BaseExecuteController.cs
+++ b/PseudoCQRS.Mvc/BaseExecuteController.cs
@@ -50,24 +50,7 @@ namespace PseudoCQRS.Controllers
 				} );
 			}
 
-			return ExecuteCommandAndGetActionResult( viewModel );
-			//ActionResult result;
-			//if ( ModelState.IsValid )
-			//{
-			//	var commandResult = ExecuteCommand( viewModel );
-			//	result = OnCompletion( viewModel, commandResult );
-			//}
-			//else
-			//{
-			//	var errorMessage = GetErrorMessage();
-			//	_messageManager.SetErrorMessage( errorMessage );
-			//	result = OnCompletion( viewModel, new CommandResult
-			//	{
-			//		ContainsError = true,
-			//		Message = errorMessage
-			//	} );
-			//}
-			//return result;
+			return ExecuteCommandAndGetActionResult( viewModel );			
 		}
 
 		protected virtual string GetErrorMessage()

--- a/PseudoCQRS.Mvc/BaseReadController.cs
+++ b/PseudoCQRS.Mvc/BaseReadController.cs
@@ -1,4 +1,5 @@
-﻿using System.Web.Mvc;
+﻿using System.Web;
+using System.Web.Mvc;
 using Microsoft.Practices.ServiceLocation;
 using PseudoCQRS.Controllers.ExtensionMethods;
 
@@ -28,7 +29,14 @@ namespace PseudoCQRS.Controllers
 
 		protected virtual TViewModel GetViewModel()
 		{
-			return _viewModelFactory.GetViewModel();
+			try
+			{
+				return _viewModelFactory.GetViewModel();
+			}
+			catch ( ArgumentBindingException exception )
+			{
+				throw new HttpException( 404, exception.Message, exception.InnerException );
+			}
 		}
 
 		protected virtual ViewResult GetViewResult( TViewModel viewModel )

--- a/PseudoCQRS.Mvc/BaseReadExecuteController.cs
+++ b/PseudoCQRS.Mvc/BaseReadExecuteController.cs
@@ -1,4 +1,7 @@
-﻿using System.Web.Mvc;
+﻿using System;
+using System.Net;
+using System.Web;
+using System.Web.Mvc;
 using Microsoft.Practices.ServiceLocation;
 using PseudoCQRS.Controllers.ExtensionMethods;
 
@@ -46,7 +49,14 @@ namespace PseudoCQRS.Controllers
 
 		protected virtual TViewModel GetViewModel()
 		{
-			return _viewModelFactory.GetViewModel();
+			try
+			{
+				return _viewModelFactory.GetViewModel();
+			}
+			catch ( ArgumentBindingException exception )
+			{
+				throw new HttpException( 404, exception.Message, exception.InnerException );
+			}
 		}
 
 		[HttpPost]

--- a/PseudoCQRS.Mvc3.nuspec
+++ b/PseudoCQRS.Mvc3.nuspec
@@ -3,8 +3,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd" >
 	<metadata>
 		<id>PseudoCQRS.Mvc3</id>
-		<version>5.0.1</version>
-		<title>Pseudo CQRS Mvc3</title>
+    <version>5.0.2</version>
+    <title>Pseudo CQRS Mvc3</title>
 		<authors>Liquid Thinking</authors>
 		<projectUrl>https://github.com/LiquidThinking/PseudoCQRS</projectUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/PseudoCQRS.Mvc4.nuspec
+++ b/PseudoCQRS.Mvc4.nuspec
@@ -3,8 +3,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd" >
 	<metadata>
 		<id>PseudoCQRS.Mvc4</id>
-		<version>5.0.1</version>
-		<title>Pseudo CQRS Mvc4</title>
+    <version>5.0.2</version>
+    <title>Pseudo CQRS Mvc4</title>
 		<authors>Liquid Thinking</authors>
 		<projectUrl>https://github.com/LiquidThinking/PseudoCQRS</projectUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/PseudoCQRS.Mvc5.nuspec
+++ b/PseudoCQRS.Mvc5.nuspec
@@ -3,8 +3,8 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd" >
 	<metadata>
 		<id>PseudoCQRS.Mvc5</id>
-		<version>5.0.1</version>
-		<title>Pseudo CQRS Mvc5</title>
+    <version>5.0.2</version>
+    <title>Pseudo CQRS Mvc5</title>
 		<authors>Liquid Thinking</authors>
 		<projectUrl>https://github.com/LiquidThinking/PseudoCQRS</projectUrl>
 		<requireLicenseAcceptance>false</requireLicenseAcceptance>

--- a/PseudoCQRS.nuspec
+++ b/PseudoCQRS.nuspec
@@ -3,7 +3,7 @@
 <package xmlns="http://schemas.microsoft.com/packaging/2011/08/nuspec.xsd" >
 	<metadata>
 		<id>PseudoCQRS</id>
-		<version>5.0.1</version>
+		<version>5.0.2</version>
 		<title>Pseudo CQRS</title>
 		<authors>Liquid Thinking</authors>
 		<projectUrl>https://github.com/LiquidThinking/PseudoCQRS</projectUrl>

--- a/PseudoCQRS/ArgumentBindingException.cs
+++ b/PseudoCQRS/ArgumentBindingException.cs
@@ -1,0 +1,22 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace PseudoCQRS
+{
+	public class ArgumentBindingException : Exception
+	{
+		public string Value { get; }
+		public Type PropertyType { get; }
+
+		public ArgumentBindingException( string value, Type propertyType, Exception innerException = null )
+			: base( String.Empty, innerException )
+		{
+			Value = value;
+			PropertyType = propertyType;
+		}
+
+		public override string Message => $"Cannot bind '{Value}' to property '{PropertyType.Name}";
+	}
+}

--- a/PseudoCQRS/PropertyValueProviders/BasePropertyValueProvider.cs
+++ b/PseudoCQRS/PropertyValueProviders/BasePropertyValueProvider.cs
@@ -34,7 +34,14 @@ namespace PseudoCQRS.PropertyValueProviders
 					return null;
 			}
 
-			return Convert.ChangeType( value, propertyType );
+			try
+			{
+				return Convert.ChangeType( value, propertyType );
+			}
+			catch ( Exception exception )
+			{
+				throw new ArgumentBindingException( value, propertyType, exception );
+			}
 		}
 	}
 }

--- a/PseudoCQRS/PseudoCQRS.csproj
+++ b/PseudoCQRS/PseudoCQRS.csproj
@@ -80,6 +80,7 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="ArgumentBindingException.cs" />
     <Compile Include="Attributes\PersistAttribute.cs" />
     <Compile Include="Checkers\BaseCheckAttribute.cs" />
     <Compile Include="Checkers\CheckersExecuter.cs" />


### PR DESCRIPTION
added ArgumentBindingException which will be raised when text provided is not compatable with property type which will be then catch in base controllers and converted into a http exception.